### PR TITLE
feat: add Route53 weighted routing support for zero-downtime migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,14 +391,14 @@ This module creates the following AWS resources:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.62, < 7.0 |
-| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | >= 5.62, < 7.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.28.0 |
+| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | 6.28.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cloudfront_logs_bucket"></a> [cloudfront\_logs\_bucket](#module\_cloudfront\_logs\_bucket) | registry.infrahouse.com/infrahouse/s3-bucket/aws | 0.3.0 |
+| <a name="module_cloudfront_logs_bucket"></a> [cloudfront\_logs\_bucket](#module\_cloudfront\_logs\_bucket) | registry.infrahouse.com/infrahouse/s3-bucket/aws | 0.3.1 |
 
 ## Resources
 
@@ -431,6 +431,9 @@ This module creates the following AWS resources:
 | <a name="input_cloudfront_logging_prefix"></a> [cloudfront\_logging\_prefix](#input\_cloudfront\_logging\_prefix) | Prefix for CloudFront log files in the logging bucket | `string` | `"cloudfront-logs/"` | no |
 | <a name="input_cloudfront_price_class"></a> [cloudfront\_price\_class](#input\_cloudfront\_price\_class) | CloudFront distribution price class. Controls which edge locations are used<br/>and affects cost:<br/>- PriceClass\_100: US, Canada, Europe (lowest cost)<br/>- PriceClass\_200: PriceClass\_100 + Asia, Africa, Oceania, Middle East<br/>- PriceClass\_All: All edge locations (highest cost, best performance globally) | `string` | `"PriceClass_100"` | no |
 | <a name="input_create_logging_bucket"></a> [create\_logging\_bucket](#input\_create\_logging\_bucket) | Create an S3 bucket for CloudFront logs using infrahouse/s3-bucket/aws module.<br/>Enables ISO 27001/SOC 2 compliant logging by default. Set to false to disable<br/>logging (not recommended for production). | `bool` | `true` | no |
+| <a name="input_dns_routing_policy"></a> [dns\_routing\_policy](#input\_dns\_routing\_policy) | DNS routing policy for Route53 records: 'simple' or 'weighted'.<br/>Use 'weighted' for zero-downtime migrations when transitioning traffic<br/>from an existing service to the redirect. | `string` | `"simple"` | no |
+| <a name="input_dns_set_identifier"></a> [dns\_set\_identifier](#input\_dns\_set\_identifier) | Unique identifier for weighted routing records. Required when dns\_routing\_policy = 'weighted'.<br/>Must be unique among all weighted records with the same DNS name.<br/>Example: 'redirect' or 'http-redirect-module' | `string` | `null` | no |
+| <a name="input_dns_weight"></a> [dns\_weight](#input\_dns\_weight) | Weight for weighted routing policy (0-255). Only used when dns\_routing\_policy = 'weighted'.<br/>Higher values receive proportionally more traffic relative to other weighted records<br/>with the same name. | `number` | `100` | no |
 | <a name="input_redirect_hostnames"></a> [redirect\_hostnames](#input\_redirect\_hostnames) | List of hostname prefixes to redirect (e.g., ['', 'www'] for apex and www<br/>subdomain). Use empty string for apex domain. | `list(string)` | <pre>[<br/>  "",<br/>  "www"<br/>]</pre> | no |
 | <a name="input_redirect_to"></a> [redirect\_to](#input\_redirect\_to) | Target URL where HTTP(S) requests will be redirected. Can be:<br/>- A hostname: 'example.com'<br/>- A hostname with path: 'example.com/landing'<br/><br/>Note: Query parameters in redirect\_to are not supported due to S3 routing<br/>rule limitations. Source query parameters will be preserved in redirects.<br/>Do not include protocol (https://). | `string` | n/a | yes |
 | <a name="input_web_acl_id"></a> [web\_acl\_id](#input\_web\_acl\_id) | Optional AWS WAF Web ACL ARN to attach to the CloudFront distribution.<br/>Provides DDoS protection and rate limiting for the redirect service.<br/><br/>Leave null (default) for most use cases. Consider enabling if:<br/>- You have compliance requirements for WAF on all resources<br/>- You're experiencing abuse or high request volumes<br/>- You need IP-based access controls<br/><br/>Note: AWS WAF incurs additional costs per web ACL and per million requests. | `string` | `null` | no |

--- a/dns.tf
+++ b/dns.tf
@@ -3,6 +3,16 @@ resource "aws_route53_record" "extra" {
   zone_id  = var.zone_id
   name     = each.value
   type     = "A"
+
+  set_identifier = var.dns_routing_policy != "simple" ? var.dns_set_identifier : null
+
+  dynamic "weighted_routing_policy" {
+    for_each = var.dns_routing_policy == "weighted" ? [1] : []
+    content {
+      weight = var.dns_weight
+    }
+  }
+
   alias {
     evaluate_target_health = false
     name                   = aws_cloudfront_distribution.redirect.domain_name
@@ -15,6 +25,16 @@ resource "aws_route53_record" "extra_aaaa" {
   zone_id  = var.zone_id
   name     = each.value
   type     = "AAAA"
+
+  set_identifier = var.dns_routing_policy != "simple" ? var.dns_set_identifier : null
+
+  dynamic "weighted_routing_policy" {
+    for_each = var.dns_routing_policy == "weighted" ? [1] : []
+    content {
+      weight = var.dns_weight
+    }
+  }
+
   alias {
     evaluate_target_health = false
     name                   = aws_cloudfront_distribution.redirect.domain_name

--- a/s3-logs.tf
+++ b/s3-logs.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "cloudfront_logs" {
 module "cloudfront_logs_bucket" {
   count   = var.create_logging_bucket ? 1 : 0
   source  = "registry.infrahouse.com/infrahouse/s3-bucket/aws"
-  version = "0.3.0"
+  version = "0.3.1"
 
   # Use zone name for bucket naming (not redirect_domains which may start with "")
   bucket_name = "${replace(data.aws_route53_zone.redirect.name, ".", "-")}-cloudfront-logs"

--- a/variables.tf
+++ b/variables.tf
@@ -132,3 +132,48 @@ variable "web_acl_id" {
   type        = string
   default     = null
 }
+
+variable "dns_routing_policy" {
+  description = <<-EOT
+    DNS routing policy for Route53 records: 'simple' or 'weighted'.
+    Use 'weighted' for zero-downtime migrations when transitioning traffic
+    from an existing service to the redirect.
+  EOT
+  type        = string
+  default     = "simple"
+
+  validation {
+    condition     = contains(["simple", "weighted"], var.dns_routing_policy)
+    error_message = "dns_routing_policy must be 'simple' or 'weighted'."
+  }
+}
+
+variable "dns_weight" {
+  description = <<-EOT
+    Weight for weighted routing policy (0-255). Only used when dns_routing_policy = 'weighted'.
+    Higher values receive proportionally more traffic relative to other weighted records
+    with the same name.
+  EOT
+  type        = number
+  default     = 100
+
+  validation {
+    condition     = var.dns_weight >= 0 && var.dns_weight <= 255
+    error_message = "dns_weight must be between 0 and 255. Got: ${var.dns_weight}"
+  }
+}
+
+variable "dns_set_identifier" {
+  description = <<-EOT
+    Unique identifier for weighted routing records. Required when dns_routing_policy = 'weighted'.
+    Must be unique among all weighted records with the same DNS name.
+    Example: 'redirect' or 'http-redirect-module'
+  EOT
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.dns_set_identifier == null ? true : length(var.dns_set_identifier) > 0
+    error_message = "dns_set_identifier cannot be an empty string when provided."
+  }
+}


### PR DESCRIPTION
  ## Summary
  - Add Route53 weighted routing policy support for DNS A/AAAA records
  - Enable zero-downtime migrations when transitioning traffic from existing services to redirects
  - Upgrade `infrahouse/s3-bucket/aws` module from 0.3.0 to 0.3.1

  ## New Variables
  | Variable | Type | Default | Description |
  |----------|------|---------|-------------|
  | `dns_routing_policy` | string | `"simple"` | DNS routing policy: `simple` or `weighted` |
  | `dns_weight` | number | `100` | Weight for weighted routing (0-255) |
  | `dns_set_identifier` | string | `null` | Unique identifier for weighted records |

  ## Use Case
  When deprecating a service and redirecting users to a new URL:
  1. Deploy redirect with `weight=0, dns_set_identifier="redirect"`
  2. Convert existing service DNS to weighted with `weight=100`
  3. Gradually shift weights (90/10 → 50/50 → 10/90 → 0/100)
  4. Remove old service record

  ## Changes
  - `variables.tf`: Added 3 new variables with validation
  - `dns.tf`: Updated A/AAAA records with dynamic weighted_routing_policy blocks
  - `s3-logs.tf`: Upgraded s3-bucket module to 0.3.1
  - `docs/configuration.md`: Added documentation for new variables

  Closes #24

