### PR TITLE
feat: exempt redirect bucket from cross-region-replication check

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,7 +1,17 @@
 resource "aws_s3_bucket" "redirect" {
   bucket_prefix = "http-redirect-"
   force_destroy = true
-  tags          = local.default_module_tags
+
+  # This bucket holds only terraform-managed static redirect configuration — no
+  # data and no audit trail — so cross-region replication adds no value. Exempt
+  # it from the aws-s3-cross-region-replication-enabled compliance check so the
+  # org-governance vanta_exemption reconciler does not flag it.
+  tags = merge(
+    local.default_module_tags,
+    {
+      "vanta-exempt:aws-s3-cross-region-replication-enabled" = "HTTP redirect bucket - terraform-managed static redirect with no data"
+    }
+  )
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "redirect" {


### PR DESCRIPTION
## Summary

Adds the `vanta-exempt:aws-s3-cross-region-replication-enabled` tag to `aws_s3_bucket.redirect`. This bucket holds only terraform-managed static redirect configuration — no data and no audit trail — so cross-region replication adds no value, and the exempt tag stops the org-governance `vanta_exemption` reconciler from flagging it.

This completes the redirect-bucket half of #36. The other half (CloudFront logs bucket CRR via `replication_region`) already shipped in 3.0.0.

## Notes

- Tag value uses only AWS-safe characters (letters, spaces, hyphens) — no comma or em-dash, which fall outside AWS's documented tag character set (`+ - = . _ : / @`).
- Tag is applied directly on the redirect bucket (merged with `local.default_module_tags`) rather than the shared local, since the logs bucket genuinely has CRR and must not be exempt.

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)